### PR TITLE
Use POST request for logging out

### DIFF
--- a/main.go
+++ b/main.go
@@ -136,7 +136,7 @@ func InitRouter() *gin.Engine {
 	r.GET("/settings", routers.Settings)
 	r.POST("/settings", routers.Settings)
 
-	r.GET("/logout", routers.Logout)
+	r.POST("/logout", routers.Logout)
 
 	r.GET("/delete/a/:aid", routers.ArticleDelete)
 	r.GET("/bad/@:author/:aid/:bad", routers.ArticleBad)

--- a/routers/routers.go
+++ b/routers/routers.go
@@ -456,10 +456,9 @@ func Settings(c *gin.Context) {
 // Logout remove cookie
 func Logout(c *gin.Context) {
 	switch c.Request.Method {
-	case "GET":
+	case "POST":
 		c.SetCookie("token", "", 0, "/", "", false, true)
 		c.Redirect(http.StatusFound, "/")
-	case "POST":
 	}
 }
 

--- a/views/settings.html
+++ b/views/settings.html
@@ -16,5 +16,7 @@
   </section>
 </form>
 <hr/>
-<a href="logout"  accesskey="o">Or click here to logout.</a>
+<form action="/logout" method="post">
+  <button type="submit" accesskey="o">Log out</button>
+</form>
 {{template "footer" .}}


### PR DESCRIPTION
With GET a malicious user can forcibly log out your users by posting an "image" with src=/logout (`![title](/logout)` in markdown).